### PR TITLE
fix server error for external resource download route

### DIFF
--- a/ckanext/s3filestore/view.py
+++ b/ckanext/s3filestore/view.py
@@ -98,6 +98,9 @@ def download(id, resource_id, filename=None):
                 return abort(404, _('Resource data not found'))
             else:
                 raise ex
+    elif u'url' not in rsc:
+        return abort(404, _(u'No download is available'))
+    return redirect(rsc[u'url'])
 
 
 def filesystem_resource_download(id, resource_id, filename=None):


### PR DESCRIPTION
fix for the server error triggered when accessing `/resource/<resource_id>/download` for external resources

`TypeError: The view function for 'hdx_download_wrapper.download' did not return a valid response. The function either returned None or ended without a return statement.`