### PR TITLE
[HDX-10598] presign HEAD as well

### DIFF
--- a/ckanext/s3filestore/helpers.py
+++ b/ckanext/s3filestore/helpers.py
@@ -5,7 +5,7 @@ import requests
 from ckantoolkit import config
 
 
-def generate_temporary_link(client, bucket_name, key_path, force_download=False, expires_in=None):
+def generate_temporary_link(client, bucket_name, key_path, force_download=False, expires_in=None, http_method=None):
 
     if not expires_in:
         expires_in = config.get('ckanext.s3filestore.link_expires_in_seconds', 60)
@@ -19,10 +19,16 @@ def generate_temporary_link(client, bucket_name, key_path, force_download=False,
         filename = key_path.split('/')[-1]
         params['ResponseContentDisposition'] = f'attachment; filename="{filename}"'
 
+    # Use the passed HTTP method or default to GET
+    kwargs = {}
+    if http_method:
+        kwargs['HttpMethod'] = http_method
+
     url = client.generate_presigned_url(
         ClientMethod='get_object',
         Params=params,
-        ExpiresIn=expires_in
+        ExpiresIn=expires_in,
+        **kwargs
     )
 
     return url

--- a/ckanext/s3filestore/view.py
+++ b/ckanext/s3filestore/view.py
@@ -76,7 +76,6 @@ def download(id, resource_id, filename=None):
             #                                             'Key': key_path},
             #                                     ExpiresIn=60)
             http_method = request.method  # Get the current HTTP method
-            log.info(f"Request HTTP method: {http_method}")
             url = generate_temporary_link(client, bucket.name, key_path, force_download, None, http_method)
             if _should_use_download_with_cache(dataset_dict['name']):
                 return _resource_download_with_cache(url, filename, rsc)

--- a/ckanext/s3filestore/view.py
+++ b/ckanext/s3filestore/view.py
@@ -75,7 +75,8 @@ def download(id, resource_id, filename=None):
             #                                     Params={'Bucket': bucket.name,
             #                                             'Key': key_path},
             #                                     ExpiresIn=60)
-            url = generate_temporary_link(client, bucket.name, key_path, force_download)
+            http_method = request.method  # Get the current HTTP method
+            url = generate_temporary_link(client, bucket.name, key_path, force_download, None, http_method)
             if _should_use_download_with_cache(dataset_dict['name']):
                 return _resource_download_with_cache(url, filename, rsc)
             else:

--- a/ckanext/s3filestore/view.py
+++ b/ckanext/s3filestore/view.py
@@ -76,6 +76,7 @@ def download(id, resource_id, filename=None):
             #                                             'Key': key_path},
             #                                     ExpiresIn=60)
             http_method = request.method  # Get the current HTTP method
+            log.info(f"Request HTTP method: {http_method}")
             url = generate_temporary_link(client, bucket.name, key_path, force_download, None, http_method)
             if _should_use_download_with_cache(dataset_dict['name']):
                 return _resource_download_with_cache(url, filename, rsc)


### PR DESCRIPTION
Currently, `request.method` seems to always return `GET`.